### PR TITLE
drivers: audio: dmic_nrfx_pdm: Reclassify log in PDM read when no dat…

### DIFF
--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -499,7 +499,7 @@ static int dmic_nrfx_pdm_read(const struct device *dev,
 
 	ret = k_msgq_get(&drv_data->rx_queue, buffer, SYS_TIMEOUT_MS(timeout));
 	if (ret != 0) {
-		LOG_ERR("No audio data to be read");
+		LOG_DBG("No audio data to be read");
 	} else {
 		LOG_DBG("Released buffer %p", *buffer);
 


### PR DESCRIPTION
…a is ready

Currently the dmic_nrfx_pdm read implementation treats a timeout as an error, in that a logging error message is produced when no PDM data is available. However, for non-(or minimally-)blocking applications this is normal behavior. Classified this way, the logger is flooded with error messages unnecessarily, unless the log level is changed for the dmic module, which is not desirable.

This modification simply changes the log-level to debug so the application user can then decide whether or not a failed read needs to produce an error message.